### PR TITLE
Deprecate inputs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 # inspec_tools_action
+THIS ACTION IS DEPRECATED. Use the [SAF Action](https://github.com/mitre/saf_action) instead.
 GitHub Action for [Inspec Tools](https://github.com/mitre/inspec_tools)
 
 ## Input and Output Arguments

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # inspec_tools_action
-THIS ACTION IS DEPRECATED. Use the [SAF Action](https://github.com/mitre/saf_action) instead.
+THIS ACTION IS DEPRECATED. Use the [SAF Action](https://github.com/marketplace/actions/saf-cli-action) instead.
 GitHub Action for [Inspec Tools](https://github.com/mitre/inspec_tools)
 
 ## Input and Output Arguments

--- a/action.yml
+++ b/action.yml
@@ -9,15 +9,15 @@ inputs:
   thresholdfile:
     description: 'Inspec Tools threshold file which sets the min/max results allowed in each category'
     required: true
-    deprecationMessage: 'THIS ACTION IS DEPRECATED. Use mitre/saf_action to replace this action. Find it here: https://github.com/mitre/saf_action'
+    deprecationMessage: 'THIS ACTION IS DEPRECATED. Use mitre/saf_action to replace this action. Find it here: https://github.com/marketplace/actions/saf-cli-action'
   resultsfile:
     description: 'Inspec results in JSON format'
     required: true
-    deprecationMessage: 'THIS ACTION IS DEPRECATED. Use mitre/saf_action to replace this action. Find it here: https://github.com/mitre/saf_action'
+    deprecationMessage: 'THIS ACTION IS DEPRECATED. Use mitre/saf_action to replace this action. Find it here: https://github.com/marketplace/actions/saf-cli-action'
   command:
     description: 'Inspec Tools command to run'
     required: true
-    deprecationMessage: 'THIS ACTION IS DEPRECATED. Use mitre/saf_action to replace this action. Find it here: https://github.com/mitre/saf_action'
+    deprecationMessage: 'THIS ACTION IS DEPRECATED. Use mitre/saf_action to replace this action. Find it here: https://github.com/marketplace/actions/saf-cli-action'
 runs:
   using: 'docker'
   image: 'Dockerfile'

--- a/action.yml
+++ b/action.yml
@@ -9,12 +9,15 @@ inputs:
   thresholdfile:
     description: 'Inspec Tools threshold file which sets the min/max results allowed in each category'
     required: true
+    deprecationMessage: 'THIS ACTION IS DEPRECATED. Use mitre/saf_action to replace this action. Find it here: https://github.com/mitre/saf_action'
   resultsfile:
     description: 'Inspec results in JSON format'
     required: true
+    deprecationMessage: 'THIS ACTION IS DEPRECATED. Use mitre/saf_action to replace this action. Find it here: https://github.com/mitre/saf_action'
   command:
     description: 'Inspec Tools command to run'
     required: true
+    deprecationMessage: 'THIS ACTION IS DEPRECATED. Use mitre/saf_action to replace this action. Find it here: https://github.com/mitre/saf_action'
 runs:
   using: 'docker'
   image: 'Dockerfile'

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -2,10 +2,6 @@
 
 set -e
 
-echo "Entering sleep"
-sleep 600
-echo "Done sleeping"
-
 if [ -n $INPUT_THRESHOLDFILE ] && [ -n $INPUT_COMMAND ] && [ -n $INPUT_RESULTFILE ]; then
   echo "Using $(inspec_tools version)"
   case "$INPUT_COMMAND" in

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -4,17 +4,17 @@ set -e
 
 echo $PATH
 echo $INPUT_THRESHOLDFILE
-echo $INPUT_RESULTFILE
+echo $INPUT_RESULTSFILE
 echo $INPUT_COMMAND
 
-if [ -n $INPUT_THRESHOLDFILE ] && [ -n $INPUT_COMMAND ] && [ -n $INPUT_RESULTFILE ]; then
+if [ -n $INPUT_THRESHOLDFILE ] && [ -n $INPUT_COMMAND ] && [ -n $INPUT_RESULTSFILE ]; then
   echo "Using $(inspec_tools version)"
   case "$INPUT_COMMAND" in
     "compliance" )
-      inspec_tools compliance -j "$INPUT_RESULTFILE" -f "$INPUT_THRESHOLDFILE"
+      inspec_tools compliance -j "$INPUT_RESULTSFILE" -f "$INPUT_THRESHOLDFILE"
       ;;
     "summary" )
-      inspec_tools summary -j "$INPUT_RESULTFILE" -t "$INPUT_THRESHOLDFILE"
+      inspec_tools summary -j "$INPUT_RESULTSFILE" -t "$INPUT_THRESHOLDFILE"
       ;;
     * )
       echo "$INPUT_COMMAND is not a valid command";

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -2,6 +2,11 @@
 
 set -e
 
+echo $PATH
+echo $INPUT_THRESHOLDFILE
+echo $INPUT_RESULTFILE
+echo $INPUT_COMMAND
+
 if [ -n $INPUT_THRESHOLDFILE ] && [ -n $INPUT_COMMAND ] && [ -n $INPUT_RESULTFILE ]; then
   echo "Using $(inspec_tools version)"
   case "$INPUT_COMMAND" in

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -2,11 +2,6 @@
 
 set -e
 
-echo $PATH
-echo $INPUT_THRESHOLDFILE
-echo $INPUT_RESULTSFILE
-echo $INPUT_COMMAND
-
 if [ -n $INPUT_THRESHOLDFILE ] && [ -n $INPUT_COMMAND ] && [ -n $INPUT_RESULTSFILE ]; then
   echo "Using $(inspec_tools version)"
   case "$INPUT_COMMAND" in

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -2,7 +2,9 @@
 
 set -e
 
-sleep 10m
+echo "Entering sleep"
+sleep 600
+echo "Done sleeping"
 
 if [ -n $INPUT_THRESHOLDFILE ] && [ -n $INPUT_COMMAND ] && [ -n $INPUT_RESULTFILE ]; then
   echo "Using $(inspec_tools version)"

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -2,6 +2,8 @@
 
 set -e
 
+sleep 10m
+
 if [ -n $INPUT_THRESHOLDFILE ] && [ -n $INPUT_COMMAND ] && [ -n $INPUT_RESULTFILE ]; then
   echo "Using $(inspec_tools version)"
   case "$INPUT_COMMAND" in


### PR DESCRIPTION
- Fixed a spelling error in environment variable `INPUT_RESULTSFILE`
- Added deprecation messages to the input to point use to SAF Action
- Added deprecation message and SAF Action link to the Readme.
Example output in workflow with deprecated inputs:
![image](https://user-images.githubusercontent.com/32680215/157127220-49fa1d67-beac-4ece-bf83-0bbaf5460b86.png)
The tests still pass, but the inputs show as deprecated with the corresponding message.